### PR TITLE
[FEAT] 회원가입/로그인 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+venv/
+env/
+ENV/
+
+# 환경변수
+.env
+
+# DB
+*.db
+*.sqlite3
+
+# IDE
+.vscode/
+.idea/
+
+# 벡터 DB
+chroma_db/
+
+# 기타
+.DS_Store

--- a/app/_debug_db.py
+++ b/app/_debug_db.py
@@ -1,0 +1,12 @@
+from sqlalchemy import create_engine, text
+from app.config import settings
+
+print("Loaded DATABASE_URL =", settings.DATABASE_URL)
+
+try:
+    engine = create_engine(settings.DATABASE_URL, pool_pre_ping=True)
+    with engine.connect() as conn:
+        print("DB says:", conn.execute(text("SELECT 1")).scalar())
+    print("✅ Engine connect OK")
+except Exception as e:
+    print("❌ Error:", type(e).__name__, "-", e)

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -1,0 +1,82 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPBearer
+from sqlalchemy.orm import Session
+from datetime import timedelta
+
+from app.database import get_db
+from app.models.user import User
+from app.schemas.auth import UserRegister, UserLogin, Token, UserResponse
+from app.services.auth_service import (
+    get_password_hash,
+    verify_password,
+    create_access_token
+)
+from app.config import settings
+from app.middleware.auth_middleware import get_current_user
+
+router = APIRouter(prefix="/api/auth", tags=["Authentication"])
+security = HTTPBearer()
+
+@router.post("/register", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
+def register(user_data: UserRegister, db: Session = Depends(get_db)):
+    """회원가입"""
+    
+    # 이메일 중복 확인
+    existing_user = db.query(User).filter(User.email == user_data.email).first()
+    if existing_user:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="이미 사용 중인 이메일입니다"
+        )
+    
+    # 비밀번호 해싱
+    hashed_password = get_password_hash(user_data.password)
+    
+    # 사용자 생성
+    new_user = User(
+        email=user_data.email,
+        name=user_data.name,
+        password_hash=hashed_password
+    )
+    
+    db.add(new_user)
+    db.commit()
+    db.refresh(new_user)
+    
+    return new_user
+
+@router.post("/login", response_model=Token)
+def login(
+    user_credentials: UserLogin,  
+    db: Session = Depends(get_db)
+):
+    """로그인"""
+    user = db.query(User).filter(User.email == user_credentials.email).first()
+    
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="이메일 또는 비밀번호가 올바르지 않습니다"
+        )
+    
+    if not verify_password(user_credentials.password, user.password_hash):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="이메일 또는 비밀번호가 올바르지 않습니다"
+        )
+    
+    access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = create_access_token(
+        data={"sub": user.email},
+        expires_delta=access_token_expires
+    )
+    
+    return {
+        "access_token": access_token,
+        "token_type": "bearer"
+    }
+
+@router.get("/me", response_model=UserResponse)
+def get_me(current_user: User = Depends(get_current_user)):
+    """현재 로그인한 사용자 정보"""
+    return current_user

--- a/app/api/test.py
+++ b/app/api/test.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/api/test", tags=["Test"])
+
+@router.get("/hello")
+def hello():
+    return {"message": "Hello from API!"}
+
+@router.post("/echo")
+def echo(text: str):
+    return {"you_said": text}

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,14 @@
+from pydantic_settings import BaseSettings
+
+class Settings(BaseSettings):
+    DATABASE_URL: str
+    SECRET_KEY: str
+    ALGORITHM: str = "HS256"
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
+    ENCRYPTION_KEY: str
+    OPENAI_API_KEY: str
+    
+    class Config:
+        env_file = ".env"
+
+settings = Settings()

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,16 @@
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+from app.config import settings
+
+engine = create_engine(settings.DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+# Dependency
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,36 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.openapi.models import SecuritySchemeType, HTTPBearer, HTTPBase
+from fastapi.security import HTTPBearer as HTTPBearerSecurity
+from app.api import test, auth
+from app.database import engine, Base
+
+# 데이터베이스 테이블 생성
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(
+    title="바로(Baro) - 고소장 작성 서비스 API",
+    description="AI 기반 고소장 자동 작성 서비스",
+    version="1.0.0"
+)
+
+# CORS 설정
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# 라우터 등록
+app.include_router(test.router)
+app.include_router(auth.router)
+
+@app.get("/")
+def read_root():
+    return {"message": "바로(Baro) API - 고소장 작성 서비스"}
+
+@app.get("/health")
+def health_check():
+    return {"status": "healthy"}

--- a/app/middleware/__init__.py
+++ b/app/middleware/__init__.py
@@ -1,0 +1,3 @@
+from app.middleware.auth_middleware import get_current_user
+
+__all__ = ["get_current_user"]

--- a/app/middleware/auth_middleware.py
+++ b/app/middleware/auth_middleware.py
@@ -1,0 +1,36 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from sqlalchemy.orm import Session
+from app.database import get_db
+from app.models.user import User
+from app.services.auth_service import verify_token
+
+security = HTTPBearer()
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+    db: Session = Depends(get_db)
+) -> User:
+    """현재 로그인한 사용자 가져오기"""
+    
+    token = credentials.credentials
+    
+    # 토큰 검증
+    token_data = verify_token(token)
+    
+    if token_data is None or token_data.email is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="유효하지 않은 토큰입니다"
+        )
+    
+    # 사용자 조회
+    user = db.query(User).filter(User.email == token_data.email).first()
+    
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="사용자를 찾을 수 없습니다"
+        )
+    
+    return user

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy.sql import func
+from app.database import Base
+
+class User(Base):
+    __tablename__ = "users"
+    
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, unique=True, index=True, nullable=False)
+    name = Column(String, nullable=False)
+    password_hash = Column(String, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -1,0 +1,36 @@
+from pydantic import BaseModel, EmailStr, field_validator
+from datetime import datetime
+from typing import Optional
+
+class UserRegister(BaseModel):
+    email: EmailStr
+    password: str
+    name: str
+    
+    @field_validator('password')
+    def validate_password(cls, v):
+        if len(v) < 8:
+            raise ValueError('비밀번호는 최소 8자 이상이어야 합니다')
+        if len(v) > 72:
+            raise ValueError('비밀번호는 최대 72자까지 가능합니다')
+        return v
+
+class UserLogin(BaseModel):
+    email: EmailStr
+    password: str
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str
+
+class TokenData(BaseModel):
+    email: Optional[str] = None
+
+class UserResponse(BaseModel):
+    id: int
+    email: str
+    name: str
+    created_at: datetime
+    
+    class Config:
+        from_attributes = True

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -1,0 +1,47 @@
+from passlib.context import CryptContext
+from jose import JWTError, jwt
+from datetime import datetime, timedelta
+from app.config import settings
+from app.schemas.auth import TokenData
+
+# 비밀번호 해싱
+pwd_context = CryptContext(schemes=["argon2"], deprecated="auto")
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """비밀번호 확인"""
+    # 72바이트 제한
+    plain_password = plain_password[:72]
+    return pwd_context.verify(plain_password, hashed_password)
+
+def get_password_hash(password: str) -> str:
+    """비밀번호 해싱"""
+    # 72바이트 제한
+    password = password[:72]
+    return pwd_context.hash(password)
+
+def create_access_token(data: dict, expires_delta: timedelta = None):
+    """JWT 토큰 생성"""
+    to_encode = data.copy()
+    
+    if expires_delta:
+        expire = datetime.utcnow() + expires_delta
+    else:
+        expire = datetime.utcnow() + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+    
+    return encoded_jwt
+
+def verify_token(token: str) -> TokenData:
+    """토큰 검증"""
+    try:
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+        email: str = payload.get("sub")
+        
+        if email is None:
+            return None
+        
+        return TokenData(email=email)
+    except JWTError:
+        return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pydantic>=2,<3
+pydantic-settings>=2,<3
+python-dotenv>=1.0


### PR DESCRIPTION
## 📌 관련 이슈 #1 
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## ✨ 수행 내용
<!-- 과제에 대한 설명을 적어주세요 -->
**회원가입 및 로그인 API 구현**
바로(Baro) 백엔드 서비스의 사용자 인증 시스템을 구축했습니다.

**주요 구현 내용:**
**JWT 기반 토큰 인증 시스템**
Argon2 해싱 알고리즘을 사용한 안전한 비밀번호 저장
PostgreSQL 데이터베이스 연동
FastAPI HTTPBearer를 통한 인증 미들웨어

**API 엔드포인트:**
POST /api/auth/register - 회원가입 (이메일, 비밀번호, 이름)
POST /api/auth/login - 로그인 (JWT 토큰 발급)
GET /api/auth/me - 현재 로그인한 사용자 정보 조회 (인증 필요)

**기술적 의사결정:**
bcrypt 대신 Argon2 사용: Python 3.13과의 호환성 문제 해결 및 더 현대적인 보안 알고리즘 채택
HTTPBearer 방식 채택: OAuth2PasswordBearer의 복잡성을 제거하고 단순한 Bearer 토큰 인증 방식 사용

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
<img width="1044" height="281" alt="스크린샷 2025-10-04 23 42 21" src="https://github.com/user-attachments/assets/782aed83-e153-447c-b219-b6baf7e77c92" />
<img width="1044" height="272" alt="스크린샷 2025-10-04 23 43 43" src="https://github.com/user-attachments/assets/95720c4e-c5a5-4d1c-94ff-c424270342bf" />
<img width="1044" height="282" alt="스크린샷 2025-10-04 23 44 37" src="https://github.com/user-attachments/assets/75d9bf59-3b87-4260-b999-413329385b61" />


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
**PostgreSQL 드라이버 오류**
문제: sqlalchemy.exc.NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:postgresql.psycopg2
해결: PostgreSQL 설치 후 psycopg2-binary 재설치


**bcrypt 호환성 문제** 
문제: Python 3.13과 bcrypt/passlib 버전 충돌로 ValueError: password cannot be longer than 72 bytes 발생
원인: bcrypt 내부 버전 확인 시 AttributeError: module 'bcrypt' has no attribute '__about__'
해결: bcrypt 대신 argon2-cffi로 전환 (CryptContext(schemes=["argon2"]))


**Swagger UI 인증 테스트 문제**
문제: Authorization 헤더가 전달되지 않음
해결: fastapi.security.HTTPBearer 사용으로 표준화
