### PR TITLE
[FEAT] 로그인 리프레시 토큰 추가

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -5,12 +5,13 @@ from datetime import timedelta
 
 from app.database import get_db
 from app.models.user import User
-from app.schemas.auth import UserRegister, UserLogin, Token, UserResponse
+from app.schemas.auth import UserRegister, UserLogin, Token, UserResponse, RefreshTokenRequest
 from app.services.auth_service import (
     get_password_hash,
     verify_password,
     create_access_token,
-    create_refresh_token
+    create_refresh_token,
+    verify_token
 )
 from app.config import settings
 from app.middleware.auth_middleware import get_current_user
@@ -82,6 +83,45 @@ def login(
     return {
         "access_token": access_token,
         "refresh_token": refresh_token,
+        "token_type": "bearer"
+    }
+
+@router.post("/refresh", response_model=Token)
+def refresh_token(token_request: RefreshTokenRequest, db: Session = Depends(get_db)):
+    """리프레시 토큰으로 새 액세스 토큰 발급"""
+    # 리프레시 토큰 검증
+    token_data = verify_token(token_request.refresh_token)
+
+    if token_data is None or token_data.email is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="유효하지 않은 리프레시 토큰입니다"
+        )
+
+    # 사용자 존재 확인
+    user = db.query(User).filter(User.email == token_data.email).first()
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="사용자를 찾을 수 없습니다"
+        )
+
+    # 새 토큰 발급
+    access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = create_access_token(
+        data={"sub": user.email},
+        expires_delta=access_token_expires
+    )
+
+    refresh_token_expires = timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS)
+    new_refresh_token = create_refresh_token(
+        data={"sub": user.email},
+        expires_delta=refresh_token_expires
+    )
+
+    return {
+        "access_token": access_token,
+        "refresh_token": new_refresh_token,
         "token_type": "bearer"
     }
 

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -9,7 +9,8 @@ from app.schemas.auth import UserRegister, UserLogin, Token, UserResponse
 from app.services.auth_service import (
     get_password_hash,
     verify_password,
-    create_access_token
+    create_access_token,
+    create_refresh_token
 )
 from app.config import settings
 from app.middleware.auth_middleware import get_current_user
@@ -20,7 +21,7 @@ security = HTTPBearer()
 @router.post("/register", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
 def register(user_data: UserRegister, db: Session = Depends(get_db)):
     """회원가입"""
-    
+
     # 이메일 중복 확인
     existing_user = db.query(User).filter(User.email == user_data.email).first()
     if existing_user:
@@ -28,10 +29,10 @@ def register(user_data: UserRegister, db: Session = Depends(get_db)):
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="이미 사용 중인 이메일입니다"
         )
-    
+
     # 비밀번호 해싱
     hashed_password = get_password_hash(user_data.password)
-    
+
     # 사용자 생성
     new_user = User(
         email=user_data.email,
@@ -39,41 +40,48 @@ def register(user_data: UserRegister, db: Session = Depends(get_db)):
         password_hash=hashed_password,
         address=user_data.address
     )
-    
+
     db.add(new_user)
     db.commit()
     db.refresh(new_user)
-    
+
     return new_user
 
 @router.post("/login", response_model=Token)
 def login(
-    user_credentials: UserLogin,  
+    user_credentials: UserLogin,
     db: Session = Depends(get_db)
 ):
     """로그인"""
     user = db.query(User).filter(User.email == user_credentials.email).first()
-    
+
     if not user:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="이메일 또는 비밀번호가 올바르지 않습니다"
         )
-    
+
     if not verify_password(user_credentials.password, user.password_hash):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="이메일 또는 비밀번호가 올바르지 않습니다"
         )
-    
+
     access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
     access_token = create_access_token(
         data={"sub": user.email},
         expires_delta=access_token_expires
     )
-    
+
+    refresh_token_expires = timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS)
+    refresh_token = create_refresh_token(
+        data={"sub": user.email},
+        expires_delta=refresh_token_expires
+    )
+
     return {
         "access_token": access_token,
+        "refresh_token": refresh_token,
         "token_type": "bearer"
     }
 

--- a/app/config.py
+++ b/app/config.py
@@ -5,6 +5,7 @@ class Settings(BaseSettings):
     SECRET_KEY: str
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
+    REFRESH_TOKEN_EXPIRE_DAYS: int = 7
     ENCRYPTION_KEY: str
     OPENAI_API_KEY: str
     

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -25,6 +25,9 @@ class Token(BaseModel):
     refresh_token: str
     token_type: str
 
+class RefreshTokenRequest(BaseModel):
+    refresh_token: str
+
 class TokenData(BaseModel):
     email: Optional[str] = None
 

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -22,6 +22,7 @@ class UserLogin(BaseModel):
 
 class Token(BaseModel):
     access_token: str
+    refresh_token: str
     token_type: str
 
 class TokenData(BaseModel):

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -20,17 +20,31 @@ def get_password_hash(password: str) -> str:
     return pwd_context.hash(password)
 
 def create_access_token(data: dict, expires_delta: timedelta = None):
-    """JWT 토큰 생성"""
+    """JWT 액세스 토큰 생성"""
     to_encode = data.copy()
-    
+
     if expires_delta:
         expire = datetime.utcnow() + expires_delta
     else:
         expire = datetime.utcnow() + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
-    
+
     to_encode.update({"exp": expire})
     encoded_jwt = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
-    
+
+    return encoded_jwt
+
+def create_refresh_token(data: dict, expires_delta: timedelta = None):
+    """JWT 리프레시 토큰 생성"""
+    to_encode = data.copy()
+
+    if expires_delta:
+        expire = datetime.utcnow() + expires_delta
+    else:
+        expire = datetime.utcnow() + timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS)
+
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+
     return encoded_jwt
 
 def verify_token(token: str) -> TokenData:


### PR DESCRIPTION
## 📌 관련 이슈 #5 
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## ✨ 수행 내용

- REFRESH_TOKEN_EXPIRE_DAYS 설정 추가 (기본값 7일)
- create_refresh_token 함수 추가
- Token 모델에 refresh_token 필드 추가
- /login 엔드포인트에서도 refresh_token 추가 반환

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
<img width="1369" height="392" alt="스크린샷 2025-10-07 17 07 42" src="https://github.com/user-attachments/assets/a82db762-63a9-44df-8307-249d65421e73" />


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
 문제 상황:
  - 액세스 토큰은 보안을 위해 짧은 만료시간 (30분)
  - 30분마다 다시 로그인하면 사용자 경험이 나쁨

  해결 방법:
  - 액세스 토큰: 짧은 수명 (30분), API 요청 시 사용
  - 리프레시 토큰: 긴 수명 (7일), 액세스 토큰 재발급용

  작동 방식:
  1. 로그인 시 두 토큰 모두 발급
  2. 액세스 토큰으로 API 요청
  3. 액세스 토큰 만료 시 → 리프레시 토큰으로 새 액세스 토큰 발급
  4. 리프레시 토큰까지 만료되면 → 재로그인 필요

  이렇게 하면 보안은 유지하면서도 사용자는 7일간 재로그인 없이 사용할 수 있다.
