### PR TITLE
[FEAT] 피고소인 정보 등록 API 구현

### DIFF
--- a/app/api/complaint.py
+++ b/app/api/complaint.py
@@ -8,7 +8,7 @@ from app.models.complaint import Complaint
 from app.schemas.complaint import (
     ComplaintCreate, ComplaintResponse, ComplaintStartResponse, ComplaintDetail,
     ComplaintUpdate, ComplaintGenerateRequest, ComplaintGenerateResponse,
-    ChatMessageCreate, ChatResponse, ComplainantInfoCreate
+    ChatMessageCreate, ChatResponse, ComplainantInfoCreate, AccusedInfoCreate
 )
 from app.middleware.auth_middleware import get_current_user
 from app.services.encryption_service import encryption_service
@@ -38,6 +38,35 @@ def register_complainant_info(
     db.refresh(new_complaint)
 
     return new_complaint
+
+
+@router.post("/info/accused/{complaint_id}", response_model=ComplaintResponse, status_code=status.HTTP_200_OK)
+def register_accused_info(
+    complaint_id: int,
+    request: AccusedInfoCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """피고소인 정보 등록 - 기존 Complaint에 피고소인 정보 추가"""
+
+    # Complaint 조회 및 권한 확인
+    complaint = db.query(Complaint).filter(
+        Complaint.id == complaint_id,
+        Complaint.user_id == current_user.id
+    ).first()
+
+    if not complaint:
+        raise HTTPException(status_code=404, detail="고소장을 찾을 수 없습니다")
+
+    # 피고소인 정보 업데이트
+    complaint.accused_name = request.accused_name
+    complaint.accused_address = request.accused_address
+    complaint.accused_phone = request.accused_phone
+
+    db.commit()
+    db.refresh(complaint)
+
+    return complaint
 
 
 @router.post("/{complaint_id}/start", response_model=ComplaintStartResponse, status_code=status.HTTP_200_OK)

--- a/app/schemas/complaint.py
+++ b/app/schemas/complaint.py
@@ -12,6 +12,12 @@ class ComplainantInfoCreate(BaseModel):
     complainant_address: str
     complainant_phone: str
 
+# 피고소인 정보 입력
+class AccusedInfoCreate(BaseModel):
+    accused_name: str
+    accused_address: str
+    accused_phone: str
+
 # 사건 정보 업데이트
 class ComplaintUpdate(BaseModel):
     accused_name: Optional[str] = None


### PR DESCRIPTION
## 📌 관련 이슈 #15 
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## ✨ 수행 내용
생성된 API 엔드포인트

  POST /api/complaints/info/accused/{complaint_id}

  주요 기능

  - 기존에 생성된 complaint에 피고소인 정보를 추가합니다
  - complaint_id를 통해 해당 고소장을 찾아 피고소인 정보를 업데이트합니다
  - 사용자 권한을 확인하여 본인의 고소장만 수정할 수 있습니다

  요청 스키마 (AccusedInfoCreate)

  {
    "accused_name": "string",
    "accused_address": "string",
    "accused_phone": "string"
  }

  응답

  - ComplaintResponse 형태로 업데이트된 고소장 정보를 반환합니다
  - HTTP 200 OK

  에러 처리

  - complaint_id를 찾을 수 없거나 권한이 없는 경우: 404 에러
  
## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
<img width="1357" height="514" alt="스크린샷 2025-10-10 18 38 26" src="https://github.com/user-attachments/assets/25e0885a-77a8-4f49-857f-a4ede70cefb3" />


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
