### PR TITLE
[FIX] Baro-AI API 호출 타임아웃 시간 수정

### DIFF
--- a/app/services/ai_service.py
+++ b/app/services/ai_service.py
@@ -9,7 +9,7 @@ class BaroAIService:
 
     def __init__(self):
         self.base_url = settings.BARO_AI_URL
-        self.timeout = 30.0
+        self.timeout = 200.0
 
     async def chat_init(self, offense: str) -> Dict[str, Any]:
         """


### PR DESCRIPTION
## 📌 관련 이슈 #17 
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## ✨ 수행 내용
baro-backend(Baro-Server)에서는 현재 Baro-AI API(채팅 세션) 호출 타임아웃을 30초로 설정해두었다.
baro-frontend와 baro-backend를 연동한 후 Swagger 테스트를 해보니 호출이 중간에 끊겼다.
baro-backend에서 Baro-AI API(채팅 세션)를 호출했을 때 타임아웃을 120초로 설정해두면 응답하였지만, 여전히 frontend에선 호출이 되지 않아 200초로 늘렸다.

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
