### PR TITLE
[FEAT] 이메일 중복 확인 API 추가

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 
 from app.database import get_db
 from app.models.user import User
-from app.schemas.auth import UserRegister, UserLogin, Token, UserResponse, RefreshTokenRequest
+from app.schemas.auth import UserRegister, UserLogin, Token, UserResponse, RefreshTokenRequest, EmailCheckResponse
 from app.services.auth_service import (
     get_password_hash,
     verify_password,
@@ -16,9 +16,28 @@ from app.services.auth_service import (
 from app.services.encryption_service import encryption_service
 from app.config import settings
 from app.middleware.auth_middleware import get_current_user
+from pydantic import EmailStr
 
 router = APIRouter(prefix="/api/auth", tags=["Authentication"])
 security = HTTPBearer()
+
+@router.get("/check-email/{email}", response_model=EmailCheckResponse)
+def check_email_availability(email: EmailStr, db: Session = Depends(get_db)):
+    """이메일 중복 확인 - 회원가입 전 이메일 사용 가능 여부 확인"""
+
+    # 데이터베이스에서 이메일 중복 확인
+    existing_user = db.query(User).filter(User.email == email).first()
+
+    if existing_user:
+        return EmailCheckResponse(
+            available=False,
+            message="이미 사용 중인 이메일입니다"
+        )
+
+    return EmailCheckResponse(
+        available=True,
+        message="사용 가능한 이메일입니다"
+    )
 
 @router.post("/register", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
 def register(user_data: UserRegister, db: Session = Depends(get_db)):

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -33,6 +33,10 @@ class RefreshTokenRequest(BaseModel):
 class TokenData(BaseModel):
     email: Optional[str] = None
 
+class EmailCheckResponse(BaseModel):
+    available: bool
+    message: str
+
 class UserResponse(BaseModel):
     id: int
     email: str


### PR DESCRIPTION
## 📌 관련 이슈 #27 
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## ✨ 수행 내용
  Before (변경 전)

  1. 회원가입 폼에 모든 정보 입력 (이메일, 비밀번호, 이름, 주소, 전화번호)
  2. 제출 버튼 클릭
  3. 서버에서 이메일 중복 체크
  4. 중복 시 → 400 에러 반환
  5. 사용자가 처음부터 다시 입력

  After (변경 후)

  1. 이메일 입력
  2. 실시간으로 중복 확인 (프론트엔드 연동 시)
  3. 즉시 피드백 제공 ("사용 가능" / "이미 사용 중")
  4. 사용 가능한 이메일로 회원가입 진행

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
<img width="1361" height="259" alt="스크린샷 2025-11-22 01 46 23" src="https://github.com/user-attachments/assets/366ccc67-e380-468c-92a7-f38d9c4c6db4" />
<img width="1361" height="465" alt="스크린샷 2025-11-22 01 46 44" src="https://github.com/user-attachments/assets/588d6184-f885-4135-b303-43b3096572db" />
<img width="1361" height="259" alt="스크린샷 2025-11-22 01 46 58" src="https://github.com/user-attachments/assets/c9135f3f-aeb0-4595-a796-8a1fa17abf66" />


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
