### PR TITLE
[FIX] AI 세션 복원 및 채팅 이어쓰기 안정화

### DIFF
--- a/app/api/complaint.py
+++ b/app/api/complaint.py
@@ -22,6 +22,38 @@ from app.utils.address_parser import get_police_station_name
 
 router = APIRouter(prefix="/api/complaints", tags=["Complaints"])
 
+INTERNAL_BOOTSTRAP_MESSAGE = "위 사건 개요를 기반으로, 고소장 작성을 위해 필요한 정보를 단계적으로 질문해 주세요."
+
+
+def is_internal_chat_message(content: str) -> bool:
+    """프론트가 첫 질문 생성을 위해 보내는 내부 메시지는 사용자 히스토리에서 제외한다."""
+    return (content or "").strip() == INTERNAL_BOOTSTRAP_MESSAGE
+
+
+def get_restore_history(db: Session, complaint_id: int, exclude_message_id: int | None = None):
+    query = db.query(ChatMessage).filter(ChatMessage.complaint_id == complaint_id)
+    if exclude_message_id is not None:
+        query = query.filter(ChatMessage.id != exclude_message_id)
+
+    messages = query.order_by(ChatMessage.created_at.asc()).all()
+    return [
+        {"role": msg.role, "content": msg.content}
+        for msg in messages
+        if msg.role == "user" and not is_internal_chat_message(msg.content)
+    ]
+
+
+async def restore_ai_session(db: Session, complaint: Complaint, exclude_message_id: int | None = None) -> str:
+    history_list = get_restore_history(
+        db=db,
+        complaint_id=complaint.id,
+        exclude_message_id=exclude_message_id
+    )
+    new_session_id = await ai_service.chat_restore_session(history_list)
+    complaint.ai_session_id = new_session_id
+    db.flush()
+    return new_session_id
+
 @router.post("/info/complainant", response_model=ComplaintResponse, status_code=status.HTTP_201_CREATED)
 def register_complainant_info(
     request: ComplainantInfoCreate,
@@ -305,53 +337,45 @@ async def send_chat_message(
     if not complaint:
         raise HTTPException(status_code=404, detail="고소장을 찾을 수 없습니다")
 
-    # 2. ai_session_id 검증 (보안: 해당 complaint의 세션인지 확인)
-    if complaint.ai_session_id != ai_session_id:
-        raise HTTPException(status_code=403, detail="유효하지 않은 세션 ID입니다")
+    # 2. 실제 AI 호출은 DB의 최신 세션 ID를 기준으로 수행한다.
+    # 프론트가 예전 ai_session_id를 보내도 complaint 소유권만 맞으면 이어쓰기를 허용한다.
+    effective_session_id = complaint.ai_session_id or ai_session_id
 
-    # 3. 사용자 메시지 저장
-    user_message = ChatMessage(
-        complaint_id=complaint_id,
-        role="user",
-        content=request.message
-    )
-    db.add(user_message)
-    db.flush()  # user_message를 DB에 반영하여 다음 sequence 계산 가능하게
+    if not effective_session_id:
+        raise HTTPException(status_code=400, detail="AI 세션이 초기화되지 않았습니다")
+
+    # 3. 사용자 메시지 저장. 단, 첫 질문 생성을 위한 내부 프롬프트는 히스토리에 노출하지 않는다.
+    should_store_user_message = not is_internal_chat_message(request.message)
+    user_message = None
+    if should_store_user_message:
+        user_message = ChatMessage(
+            complaint_id=complaint_id,
+            role="user",
+            content=request.message
+        )
+        db.add(user_message)
+        db.flush()  # user_message를 DB에 반영하여 복원 제외 조건에 활용
 
     # 4. Baro-AI에 메시지 전송 (세션 복원 로직 포함)
     try:
         ai_response = await ai_service.chat_send(
-            session_id=ai_session_id,
+            session_id=effective_session_id,
             message=request.message
         )
     except RuntimeError as e:
-        error_msg = str(e)
-
-        # 세션을 찾을 수 없는 경우 (Render sleep 후 재시작)
-        if "세션을 찾을 수 없습니다" in error_msg or "404" in error_msg:
+        # 세션을 찾을 수 없는 경우 (AI 서버 재시작 등)
+        if ai_service.is_session_missing_error(e):
             try:
-                # DB에서 이전 채팅 히스토리 가져오기 (현재 메시지 제외)
-                chat_history = db.query(ChatMessage).filter(
-                    ChatMessage.complaint_id == complaint_id,
-                    ChatMessage.id != user_message.id  # 방금 저장한 메시지는 제외
-                ).order_by(ChatMessage.created_at.asc()).all()
-
-                # 채팅 히스토리를 dict 리스트로 변환
-                history_list = [
-                    {"role": msg.role, "content": msg.content}
-                    for msg in chat_history
-                ]
-
-                # 세션 복원
-                new_session_id = await ai_service.chat_restore_session(history_list)
-
-                # DB에 새 세션 ID 업데이트
-                complaint.ai_session_id = new_session_id
-                db.flush()
+                exclude_message_id = user_message.id if user_message else None
+                effective_session_id = await restore_ai_session(
+                    db=db,
+                    complaint=complaint,
+                    exclude_message_id=exclude_message_id
+                )
 
                 # 복원된 세션으로 메시지 재전송
                 ai_response = await ai_service.chat_send(
-                    session_id=new_session_id,
+                    session_id=effective_session_id,
                     message=request.message
                 )
             except Exception as restore_error:
@@ -362,7 +386,7 @@ async def send_chat_message(
         else:
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail=f"AI 서비스 연결 실패: {error_msg}"
+                detail=f"AI 서비스 연결 실패: {str(e)}"
             )
     except Exception as e:
         raise HTTPException(
@@ -383,7 +407,8 @@ async def send_chat_message(
     db.commit()
 
     return ChatResponse(
-        reply=reply
+        reply=reply,
+        session_id=effective_session_id
     )
 
 @router.get("/{complaint_id}/chat/history", response_model=ChatHistoryResponse)
@@ -407,6 +432,11 @@ def get_chat_history(
     messages = db.query(ChatMessage).filter(
         ChatMessage.complaint_id == complaint_id
     ).order_by(ChatMessage.created_at.asc()).all()
+    messages = [
+        message
+        for message in messages
+        if not (message.role == "user" and is_internal_chat_message(message.content))
+    ]
 
     return ChatHistoryResponse(messages=messages)
 
@@ -430,36 +460,19 @@ async def generate_complaint(
 
     # Baro-AI에 고소장 작성 요청 (세션 복원 로직 포함)
     try:
-        ai_response = await ai_service.chat_compose(complaint.ai_session_id)
+        effective_session_id = complaint.ai_session_id
+        ai_response = await ai_service.chat_compose(effective_session_id)
         sections = ai_response.get("sections", {})
         criminal_facts = sections.get("criminal_facts", "")
         accusation_reason = sections.get("accusation_reason", "")
     except RuntimeError as e:
-        error_msg = str(e)
-
-        # 세션을 찾을 수 없는 경우 (Render sleep 후 재시작)
-        if "세션을 찾을 수 없습니다" in error_msg or "404" in error_msg:
+        # 세션을 찾을 수 없는 경우 (AI 서버 재시작 등)
+        if ai_service.is_session_missing_error(e):
             try:
-                # DB에서 채팅 히스토리 가져오기
-                chat_history = db.query(ChatMessage).filter(
-                    ChatMessage.complaint_id == complaint_id
-                ).order_by(ChatMessage.created_at.asc()).all()
-
-                # 채팅 히스토리를 dict 리스트로 변환
-                history_list = [
-                    {"role": msg.role, "content": msg.content}
-                    for msg in chat_history
-                ]
-
-                # 세션 복원
-                new_session_id = await ai_service.chat_restore_session(history_list)
-
-                # DB에 새 세션 ID 업데이트
-                complaint.ai_session_id = new_session_id
-                db.flush()
+                effective_session_id = await restore_ai_session(db=db, complaint=complaint)
 
                 # 복원된 세션으로 고소장 작성 재요청
-                ai_response = await ai_service.chat_compose(new_session_id)
+                ai_response = await ai_service.chat_compose(effective_session_id)
                 sections = ai_response.get("sections", {})
                 criminal_facts = sections.get("criminal_facts", "")
                 accusation_reason = sections.get("accusation_reason", "")
@@ -471,7 +484,7 @@ async def generate_complaint(
         else:
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail=f"AI 서비스 연결 실패: {error_msg}"
+                detail=f"AI 서비스 연결 실패: {str(e)}"
             )
     except Exception as e:
         raise HTTPException(

--- a/app/schemas/complaint.py
+++ b/app/schemas/complaint.py
@@ -110,6 +110,7 @@ class ChatHistoryResponse(BaseModel):
 
 class ChatResponse(BaseModel):
     reply: str  # AI 응답 메시지
+    session_id: Optional[str] = None  # 현재 유효한 Baro-AI 세션 ID
 
 # 고소장 응답
 class ComplaintResponse(BaseModel):

--- a/app/services/ai_service.py
+++ b/app/services/ai_service.py
@@ -11,6 +11,12 @@ class BaroAIService:
         self.base_url = settings.BARO_AI_URL
         self.timeout = 200.0
 
+    @staticmethod
+    def is_session_missing_error(error: Exception) -> bool:
+        """Baro-AI의 인메모리 세션 유실 여부를 판별한다."""
+        error_msg = str(error)
+        return "세션을 찾을 수 없습니다" in error_msg or "404" in error_msg
+
     async def chat_init(self, text: str) -> Dict[str, Any]:
         """
         Baro-AI 채팅 세션 초기화 (사건개요 기반)


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
 closed #43 

## ✨ 수행 내용
 - 채팅 전송 시 프론트가 전달한 path의 `ai_session_id`를 절대 기준으로 검증하지 않
  도록 수정했습니다.
  - 실제 Baro-AI 호출은 DB에 저장된 최신 `complaint.ai_session_id`를 기준으로 수행하
  도록 변경했습니다.
  - Baro-AI 세션이 유실된 경우 DB 채팅 히스토리 기반으로 세션을 복원하고, 새 세션 ID
  를 `complaint.ai_session_id`에 반영하도록 정리했습니다.
  - `/generate`에서도 동일한 세션 복원 흐름을 적용했습니다.
  - 프론트가 첫 질문 생성을 위해 보내는 내부 자동 프롬프트는 사용자 채팅 히스토리에
  저장하지 않도록 처리했습니다.
  - 기존에 저장된 내부 자동 프롬프트도 채팅 히스토리 응답 및 세션 복원 대상에서 제외
  되도록 필터링했습니다.
  - `ChatResponse`에 현재 유효한 `session_id`를 선택 필드로 추가했습니다.
    - 기존 프론트는 `reply`만 사용하므로 기존 응답 호환성은 유지됩니다.

  ## 📸 스크린샷(선택)

  API/서버 로직 수정으로 별도 스크린샷은 없습니다.

  ## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

  - Baro-AI는 현재 세션을 인메모리 dict로 관리하므로 컨테이너 재시작, 서버 재부팅,
  배포 시 기존 세션이 유실될 수 있습니다.
  - 이번 PR에서는 프론트 변경 없이 baro-server가 DB의 `complaint.ai_session_id`를 기
  준으로 최신 세션을 관리하도록 우선 보완했습니다.
  - 추후 Baro-AI에 `/chat/restore` API를 추가하면, 세션 복원 책임을 AI 서버 쪽으로
  더 명확하게 분리할 수 있습니다.

  검증:
  - `PYTHONPYCACHEPREFIX=/private/tmp/baro-pycache python3 -m compileall app`
