### PR TITLE
[FIX] Baro-AI /chat/restore 연동으로 세션 복원 로직 개선

### DIFF
--- a/app/api/complaint.py
+++ b/app/api/complaint.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
-from typing import List
+from typing import List, Optional
 
 from app.database import get_db
 from app.models.user import User
@@ -30,7 +30,7 @@ def is_internal_chat_message(content: str) -> bool:
     return (content or "").strip() == INTERNAL_BOOTSTRAP_MESSAGE
 
 
-def get_restore_history(db: Session, complaint_id: int, exclude_message_id: int | None = None):
+def get_restore_history(db: Session, complaint_id: int, exclude_message_id: Optional[int] = None):
     query = db.query(ChatMessage).filter(ChatMessage.complaint_id == complaint_id)
     if exclude_message_id is not None:
         query = query.filter(ChatMessage.id != exclude_message_id)
@@ -43,7 +43,7 @@ def get_restore_history(db: Session, complaint_id: int, exclude_message_id: int 
     ]
 
 
-async def restore_ai_session(db: Session, complaint: Complaint, exclude_message_id: int | None = None) -> str:
+async def restore_ai_session(db: Session, complaint: Complaint, exclude_message_id: Optional[int] = None) -> str:
     history_list = get_restore_history(
         db=db,
         complaint_id=complaint.id,

--- a/app/services/ai_service.py
+++ b/app/services/ai_service.py
@@ -123,32 +123,35 @@ class BaroAIService:
         if not chat_history:
             raise RuntimeError("채팅 히스토리가 비어있습니다.")
 
-        # 첫 번째 사용자 메시지로 세션 초기화
-        first_message = next((msg for msg in chat_history if msg["role"] == "user"), None)
-        if not first_message:
+        if not any(msg.get("role") == "user" for msg in chat_history):
             raise RuntimeError("사용자 메시지를 찾을 수 없습니다.")
 
-        # /chat/init으로 새 세션 생성
-        init_response = await self.chat_init(first_message["content"])
-        new_session_id = init_response.get("session_id")
-
-        # 나머지 사용자 메시지들을 순차적으로 재전송하여 세션 복원
-        # (첫 메시지는 이미 init에서 보냈으므로 스킵)
-        skip_first = True
-        for msg in chat_history:
-            if msg["role"] != "user":
-                continue
-            if skip_first:
-                skip_first = False
-                continue
-
-            # 각 사용자 메시지를 재전송
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.post(
+                    f"{self.base_url}/chat/restore",
+                    json={"history": chat_history}
+                )
+                response.raise_for_status()
+                data = response.json()
+        except httpx.HTTPStatusError as e:
+            error_detail = "Baro-AI 세션 복원 오류"
             try:
-                await self.chat_send(new_session_id, msg["content"])
-            except Exception as e:
-                # 복원 중 에러가 발생해도 계속 진행
-                print(f"세션 복원 중 경고: {str(e)}")
-                continue
+                error_body = e.response.json()
+                error_detail = error_body.get("detail", str(error_body))
+            except:
+                error_detail = e.response.text or str(e)
+            raise RuntimeError(f"Baro-AI 세션 복원 오류 ({e.response.status_code}): {error_detail}")
+        except httpx.TimeoutException:
+            raise RuntimeError("Baro-AI 세션 복원 응답 시간 초과")
+        except httpx.ConnectError:
+            raise RuntimeError("Baro-AI 서버에 연결할 수 없습니다. 서버가 실행 중인지 확인하세요.")
+        except Exception as e:
+            raise RuntimeError(f"예상치 못한 세션 복원 오류: {str(e)}")
+
+        new_session_id = data.get("session_id")
+        if not new_session_id:
+            raise RuntimeError("Baro-AI 세션 복원 응답에 session_id가 없습니다.")
 
         return new_session_id
 


### PR DESCRIPTION
## 📌 관련 이슈
  <!-- 관련있는 이슈 번호(#000)을 적어주세요.
    해당 pull request merge와 함께 이슈를 닫으려면
    closed #Issue_number를 적어주세요 -->

  closed #45 

  ## ✨ 수행 내용

  - Baro-AI 세션 복원 시 기존 `/chat/init` + `/chat/send` 반복 호출 방식 대신
  Baro-AI의 `/chat/restore` API를 사용하도록 수정했습니다.
  - `BaroAIService.chat_restore_session()`에서 DB 채팅 히스토리를 `{"history":
  [...]}` 형태로 Baro-AI에 전달하도록 변경했습니다.
  - `/chat/restore` 응답의 `session_id`를 반환하여 기존
  `complaint.ai_session_id` 갱신 흐름과 연동되도록 했습니다.
  - Baro-AI 세션 복원 API 호출 실패 케이스를 기존 서비스 에러 처리 방식에 맞춰
  `RuntimeError`로 변환했습니다.
    - HTTP status error
    - timeout
    - connection error
    - `session_id` 누락 응답
  - 기존 `complaint.py`의 채팅 전송 및 고소장 생성 복원 흐름은 유지하면서, 내부
  복원 구현만 Baro-AI restore API 기반으로 교체했습니다.

  ## 📸 스크린샷(선택)

  API/서버 로직 수정으로 별도 스크린샷은 없습니다.

  ## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

  검증:
  - [x] Baro-AI `/chat/restore` 단독 호출 확인
  - [x] baro-server 문법 검증 통과
  - [x] 로컬 프론트 + baro-server + Baro-AI + PostgreSQL 통합 실행 확인
  - [x] 채팅 중 Baro-AI 서버 재시작 후 같은 채팅창에서 메시지 전송 시 정상 응답
    확인

  참고:

  - 복원 흐름:

    기존 session_id로 /chat/send 시도
    → Baro-AI 세션 없음
    → baro-server가 DB 히스토리로 /chat/restore 호출
    → 새 session_id 저장
    → 방금 사용자 메시지를 새 세션으로 재전송
    → 정상 응답 반환