### PR TITLE
[FIX] 회원가입 선택 입력값 처리

### DIFF
--- a/alembic/versions/7f3a2b1c9d4e_make_user_address_phone_nullable.py
+++ b/alembic/versions/7f3a2b1c9d4e_make_user_address_phone_nullable.py
@@ -1,0 +1,52 @@
+"""Make user address and phone nullable
+
+Revision ID: 7f3a2b1c9d4e
+Revises: eda74b57f2cd
+Create Date: 2026-05-27 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '7f3a2b1c9d4e'
+down_revision: Union[str, Sequence[str], None] = 'eda74b57f2cd'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Allow optional address and phone number during registration."""
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    if 'users' not in inspector.get_table_names():
+        return
+
+    columns = {col['name']: col for col in inspector.get_columns('users')}
+
+    if 'address' in columns and not columns['address'].get('nullable', True):
+        op.alter_column('users', 'address', existing_type=sa.LargeBinary(), nullable=True)
+
+    if 'phone_number' in columns and not columns['phone_number'].get('nullable', True):
+        op.alter_column('users', 'phone_number', existing_type=sa.LargeBinary(), nullable=True)
+
+
+def downgrade() -> None:
+    """Restore required address and phone number constraints."""
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    if 'users' not in inspector.get_table_names():
+        return
+
+    columns = {col['name']: col for col in inspector.get_columns('users')}
+
+    if 'address' in columns and columns['address'].get('nullable', True):
+        op.alter_column('users', 'address', existing_type=sa.LargeBinary(), nullable=False)
+
+    if 'phone_number' in columns and columns['phone_number'].get('nullable', True):
+        op.alter_column('users', 'phone_number', existing_type=sa.LargeBinary(), nullable=False)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -10,8 +10,8 @@ class User(Base):
     email = Column(String, unique=True, index=True, nullable=False)
     name = Column(LargeBinary, nullable=False)  # 암호화
     password_hash = Column(String, nullable=False)
-    address = Column(LargeBinary, nullable=False)  # 암호화
-    phone_number = Column(LargeBinary, nullable=False)  # 암호화
+    address = Column(LargeBinary, nullable=True)  # 암호화
+    phone_number = Column(LargeBinary, nullable=True)  # 암호화
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -7,8 +7,8 @@ class UserRegister(BaseModel):
     email: EmailStr
     password: str
     name: str
-    address: str
-    phone_number: str
+    address: Optional[str] = None
+    phone_number: Optional[str] = None
 
     @field_validator('password')
     def validate_password(cls, v):
@@ -41,8 +41,8 @@ class UserResponse(BaseModel):
     id: int
     email: str
     name: str
-    address: str
-    phone_number: str
+    address: Optional[str] = None
+    phone_number: Optional[str] = None
     created_at: datetime
 
     @model_validator(mode='before')


### PR DESCRIPTION
## 📌 관련 이슈
없음

  ## ✨ 수행 내용
  - 회원가입 요청에서 `address`, `phone_number`를 선택값으로 허용했습니다.
  - 사용자 응답 스키마에서도 두 필드를 nullable로 허용했습니다.
  - `users.address`, `users.phone_number` DB 컬럼을 nullable로 변경하는 Alembic 마이그레이션을 추가했습니다.

  ## 📸 스크린샷(선택)
  없음

  ## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
  검증:
  - `python -m compileall ...` 통과
  - 로컬 DB에서는 `python -m alembic upgrade head` 적용 후 회원가입 확인 필요
