### PR TITLE
[FIX] 채팅 히스토리 순서 안정화

### DIFF
--- a/alembic/versions/2a8f7d5c9b31_add_rag_metadata_to_complaints.py
+++ b/alembic/versions/2a8f7d5c9b31_add_rag_metadata_to_complaints.py
@@ -1,0 +1,48 @@
+"""Add RAG metadata to complaints
+
+Revision ID: 2a8f7d5c9b31
+Revises: 7f3a2b1c9d4e
+Create Date: 2026-05-31 13:30:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '2a8f7d5c9b31'
+down_revision: Union[str, Sequence[str], None] = '7f3a2b1c9d4e'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    if 'complaints' in inspector.get_table_names():
+        columns = [col['name'] for col in inspector.get_columns('complaints')]
+
+        if 'rag_keyword' not in columns:
+            op.add_column('complaints', sa.Column('rag_keyword', sa.String(), nullable=True))
+
+        if 'rag_cases' not in columns:
+            op.add_column('complaints', sa.Column('rag_cases', sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    if 'complaints' in inspector.get_table_names():
+        columns = [col['name'] for col in inspector.get_columns('complaints')]
+
+        if 'rag_cases' in columns:
+            op.drop_column('complaints', 'rag_cases')
+
+        if 'rag_keyword' in columns:
+            op.drop_column('complaints', 'rag_keyword')

--- a/app/api/complaint.py
+++ b/app/api/complaint.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 from typing import List, Optional
+import json
 
 from app.database import get_db
 from app.models.user import User
@@ -22,12 +23,15 @@ from app.utils.address_parser import get_police_station_name
 
 router = APIRouter(prefix="/api/complaints", tags=["Complaints"])
 
-INTERNAL_BOOTSTRAP_MESSAGE = "위 사건 개요를 기반으로, 고소장 작성을 위해 필요한 정보를 단계적으로 질문해 주세요."
+INTERNAL_BOOTSTRAP_MESSAGES = {
+    "위 사건 개요를 기반으로, 이어서 질문을 해 주세요.",
+    "위 사건 개요를 기반으로, 고소장 작성을 위해 필요한 정보를 단계적으로 질문해 주세요.",
+}
 
 
 def is_internal_chat_message(content: str) -> bool:
     """프론트가 첫 질문 생성을 위해 보내는 내부 메시지는 사용자 히스토리에서 제외한다."""
-    return (content or "").strip() == INTERNAL_BOOTSTRAP_MESSAGE
+    return (content or "").strip() in INTERNAL_BOOTSTRAP_MESSAGES
 
 
 def get_restore_history(db: Session, complaint_id: int, exclude_message_id: Optional[int] = None):
@@ -35,7 +39,7 @@ def get_restore_history(db: Session, complaint_id: int, exclude_message_id: Opti
     if exclude_message_id is not None:
         query = query.filter(ChatMessage.id != exclude_message_id)
 
-    messages = query.order_by(ChatMessage.created_at.asc()).all()
+    messages = query.order_by(ChatMessage.id.asc()).all()
     return [
         {"role": msg.role, "content": msg.content}
         for msg in messages
@@ -217,6 +221,8 @@ async def init_chat_session(
     # 3. Complaint 업데이트 (crime_type, ai_session_id 설정)
     complaint.crime_type = offense
     complaint.ai_session_id = session_id
+    complaint.rag_keyword = rag_keyword
+    complaint.rag_cases = rag_cases_data
 
     # 4. 사용자의 첫 메시지 저장
     user_message = ChatMessage(
@@ -227,25 +233,10 @@ async def init_chat_session(
     db.add(user_message)
     db.flush()  # user_message를 DB에 반영하여 다음 sequence 계산 가능하게
 
-    # 5. AI 응답 메시지 저장 (offense, rag_keyword, rag_cases를 JSON으로 저장)
-    import json
-    ai_response_content = json.dumps({
-        "offense": offense,
-        "rag_keyword": rag_keyword,
-        "rag_cases": rag_cases_data
-    }, ensure_ascii=False)
-
-    assistant_message = ChatMessage(
-        complaint_id=complaint_id,
-        role="assistant",
-        content=ai_response_content
-    )
-    db.add(assistant_message)
-
     db.commit()
     db.refresh(complaint)
 
-    # 6. 응답 (죄목 + 판례)
+    # 5. 응답 (죄목 + 판례)
     rag_cases = [RagCase(**case) for case in rag_cases_data]
 
     return ChatInitResponse(
@@ -428,17 +419,44 @@ def get_chat_history(
     if not complaint:
         raise HTTPException(status_code=404, detail="고소장을 찾을 수 없습니다")
 
-    # 2. 해당 complaint의 모든 채팅 메시지 조회 (시간순 정렬)
+    # 2. 해당 complaint의 모든 채팅 메시지 조회 (저장 순서 정렬)
     messages = db.query(ChatMessage).filter(
         ChatMessage.complaint_id == complaint_id
-    ).order_by(ChatMessage.created_at.asc()).all()
+    ).order_by(ChatMessage.id.asc()).all()
+
+    fallback_meta = None
+    meta_message_ids = set()
+    for message in messages:
+        if message.role != "assistant":
+            continue
+        try:
+            parsed = json.loads(message.content)
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if isinstance(parsed, dict) and any(key in parsed for key in ("offense", "rag_keyword", "rag_cases")):
+            meta_message_ids.add(message.id)
+            if fallback_meta is None:
+                fallback_meta = parsed
+
     messages = [
         message
         for message in messages
-        if not (message.role == "user" and is_internal_chat_message(message.content))
+        if message.id not in meta_message_ids
+        and not (message.role == "user" and is_internal_chat_message(message.content))
     ]
 
-    return ChatHistoryResponse(messages=messages)
+    rag_cases_data = complaint.rag_cases
+    if not rag_cases_data and fallback_meta:
+        rag_cases_data = fallback_meta.get("rag_cases") or []
+
+    rag_cases = [RagCase(**case) for case in (rag_cases_data or [])]
+
+    return ChatHistoryResponse(
+        messages=messages,
+        offense=complaint.crime_type or (fallback_meta or {}).get("offense"),
+        rag_keyword=complaint.rag_keyword or (fallback_meta or {}).get("rag_keyword"),
+        rag_cases=rag_cases,
+    )
 
 @router.post("/{complaint_id}/generate", response_model=ComplaintGenerateResponse)
 async def generate_complaint(

--- a/app/models/complaint.py
+++ b/app/models/complaint.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Text, DateTime, ForeignKey, LargeBinary, Boolean
+from sqlalchemy import Column, Integer, String, Text, DateTime, ForeignKey, LargeBinary, Boolean, JSON
 from sqlalchemy.sql import func
 from sqlalchemy.orm import relationship
 from app.database import Base
@@ -51,6 +51,8 @@ class Complaint(Base):
 
     # Baro-AI 세션 ID
     ai_session_id = Column(String, nullable=True)  # Baro-AI의 session_id
+    rag_keyword = Column(String, nullable=True)
+    rag_cases = Column(JSON, nullable=True)
 
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/app/schemas/complaint.py
+++ b/app/schemas/complaint.py
@@ -107,6 +107,9 @@ class ChatMessageResponse(BaseModel):
 
 class ChatHistoryResponse(BaseModel):
     messages: List[ChatMessageResponse]
+    offense: Optional[str] = None
+    rag_keyword: Optional[str] = None
+    rag_cases: List[RagCase] = Field(default_factory=list)
 
 class ChatResponse(BaseModel):
     reply: str  # AI 응답 메시지


### PR DESCRIPTION
## ✨ 수행 내용
  - 채팅 히스토리 조회 및 AI 세션 복원 시 `created_at` 대신 `chat_messages.id` 기준으로 정렬하도록 변경했습니다.
    - 같은 transaction에서 저장된 user/assistant 메시지의 `created_at`이 같아져 순서가 꼬이는 문제를 방지합니다.
  - RAG 메타 정보(`rag_keyword`, `rag_cases`)를 `chat_messages`의 assistant 메시지로 저장하지 않고 `complaints` 컬럼으로 분리했습니다.
  - `complaints` 테이블에 `rag_keyword`, `rag_cases` 컬럼을 추가하는 Alembic migration을 추가했습니다.
  - 기존 DB에 남아 있는 과거 RAG 메타 메시지는 히스토리 응답에서 숨기고, 응답 최상위 메타 필드로 fallback 처리되도록 했습니다.
  - 내부 자동 메시지 문구 2종을 모두 사용자 히스토리/AI 세션 복원 대상에서 제외하도록 처리했습니다.

  ## 📸 스크린샷(선택)
  - 로컬 테스트에서 이어쓰기 진입 시 기존 채팅 순서가 정상적으로 유지되는 것을 확인했습니다.

  ## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- ⚠️ 프론트 대응 필요: `/chat/history` 응답이 기존 `messages` 배열 중심에서 `{ messages, offense, rag_keyword, rag_cases }` 객체 형태로 확장되었습니다. 채팅 렌더링은 `response.messages`를 사용하고, RAG 메타 복원은 최상위
  `offense`, `rag_keyword`, `rag_cases`를 사용하면 됩니다.
