### PR TITLE
[FIX] 사용자 선택 offense 전달 누락 수정

### DIFF
--- a/app/api/complaint.py
+++ b/app/api/complaint.py
@@ -207,7 +207,10 @@ async def init_chat_session(
 
     # 2. Baro-AI 채팅 세션 초기화 (사건개요 전송)
     try:
-        ai_response = await ai_service.chat_init(request.text)
+        ai_response = await ai_service.chat_init(
+            text=request.text,
+            offense=request.offense
+        )
         session_id = ai_response.get("session_id")
         offense = ai_response.get("offense")
         rag_keyword = ai_response.get("rag_keyword")

--- a/app/schemas/complaint.py
+++ b/app/schemas/complaint.py
@@ -7,6 +7,7 @@ from app.services.encryption_service import encryption_service
 # 채팅 초기화 요청 (사건개요 입력)
 class ChatInitRequest(BaseModel):
     text: str  # 사건 개요
+    offense: Optional[str] = None  # 프론트에서 선택한 범죄 유형
 
 # RAG 판례 정보
 class RagCase(BaseModel):

--- a/app/services/ai_service.py
+++ b/app/services/ai_service.py
@@ -1,6 +1,6 @@
 """Baro-AI 서비스 호출 클라이언트"""
 import httpx
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 from app.config import settings
 
 
@@ -17,12 +17,13 @@ class BaroAIService:
         error_msg = str(error)
         return "세션을 찾을 수 없습니다" in error_msg or "404" in error_msg
 
-    async def chat_init(self, text: str) -> Dict[str, Any]:
+    async def chat_init(self, text: str, offense: Optional[str] = None) -> Dict[str, Any]:
         """
         Baro-AI 채팅 세션 초기화 (사건개요 기반)
 
         Args:
             text: 사건 개요
+            offense: 프론트에서 선택한 범죄 유형
 
         Returns:
             {
@@ -41,10 +42,14 @@ class BaroAIService:
             }
         """
         try:
+            payload = {"text": text}
+            if offense:
+                payload["offense"] = offense
+
             async with httpx.AsyncClient(timeout=self.timeout) as client:
                 response = await client.post(
                     f"{self.base_url}/chat/init",
-                    json={"text": text}
+                    json=payload
                 )
                 response.raise_for_status()
                 return response.json()


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#49 

## ✨ 수행 내용
  - 프론트에서 전달하는 `offense` 값을 백엔드 채팅 초기화 요청 스키마에서 받을 수 있도록 수정했습니다.
  - `BaroAIService.chat_init()`이 `offense` 인자를 받을 수 있도록 변경했습니다.
  - Baro-AI `/chat/init` 호출 시 `text`와 함께 `offense`를 요청 payload에 포함하도록 수정했습니다.
  - `/api/complaints/{complaint_id}/chat/init`에서 `request.offense`를 Baro-AI 서비스 호출부로 전달하도록 수정했습니다.

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
